### PR TITLE
Fix RE to filter dist directory

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -10,7 +10,7 @@ shopt -s extglob dotglob
 rm -rf !(.git|.|..)
 cp -r $2/$3/!(.git|.|..) .
 if [ -a .gitignore ];then
-  grep -ve "^(dist|/.*.js)$" .gitignore > .gitignore.new
+  grep -vE "^(dist/?|/.*.js)$" .gitignore > .gitignore.new
   mv -f .gitignore.new .gitignore
 fi
 


### PR DESCRIPTION
Regular regex doesn't support groups, and it didn't filtered dist folder on ci. Also added support for notation with slash `dist/`