### PR TITLE
clean bower cache first

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,13 +14,16 @@ var options = commandLineArgs([
 require('child_process')
   .spawn(__dirname + '/release.sh', [packageJson.version, workingDir, options.dist, options['git-repo'], options.branch], {stdio: 'inherit'})
   .on('close', function () {
-    console.log('checking if repo needs registering in bower');
-    bower.commands.lookup(bowerJson.name).on('end', function(result) {
-      if(!result) {
-        console.log('registering the new repo in bower');
-        bower.commands.register(bowerJson.name, options['git-repo']);
-      } else {
-        console.log('already registered in bower');
-      }
+    console.log('clean bower cache');
+    bower.commands.cache.clean().on('end', function () {
+      console.log('checking if repo needs registering in bower');
+      bower.commands.lookup(bowerJson.name).on('end', function (result) {
+        if (!result) {
+          console.log('registering the new repo in bower');
+          bower.commands.register(bowerJson.name, options['git-repo']);
+        } else {
+          console.log('already registered in bower');
+        }
+      });
     });
   });


### PR DESCRIPTION
Use case - migrating from one registry to a new one. 
The package might already be cached locally on and won't get registered in the new registry